### PR TITLE
dump: x265 3.5 -> 4.0

### DIFF
--- a/Dockerfile.ubuntu2404
+++ b/Dockerfile.ubuntu2404
@@ -50,7 +50,7 @@ ARG VMAF_VERSION=v3.0.0
 ## renovate: datasource=git-refs packageName=https://code.videolan.org/videolan/x264.git branch=stable versioning=git
 ARG X264_VERSION=31e19f92f00c7003fa115047ce50978bc98c3a0d
 ## renovate: datasource=git-refs packageName=https://bitbucket.org/multicoreware/x265_git.git versioning=semver
-ARG X265_VERSION=3.5
+ARG X265_VERSION=4.0
 
 
 # retry dns and some http codes that might be transient errors


### PR DESCRIPTION
[multicoreware / x265_git — Bitbucket](https://bitbucket.org/multicoreware/x265_git/src/4.0/)